### PR TITLE
Documentation update for options missing in targetGlobalSettings()

### DIFF
--- a/src/pages/implement/client-side/atjs/atjs-functions/targetglobalsettings.md
+++ b/src/pages/implement/client-side/atjs/atjs-functions/targetglobalsettings.md
@@ -49,10 +49,16 @@ You can override settings in the at.js library using `targetGlobalSettings()`, r
 
 You can override the following settings:
 
+### artifactLocation
+
+* **Type**: String
+* **Default Value**: None
+* **Description**: A fully qualified url to the [on-device decisioning rule artifact](../../sdk-guides/on-device-decisioning/rule-artifact/index.md). Overrides internally determined location.
+
 ### bodyHiddenStyle
 
 * **Type**: String
-* **Default Value**: body { opacity: 0 } 
+* **Default Value**: body { opacity: 0 }
 * **Description**: Used only when `globalMboxAutocreate === true` to minimize the chance of flicker.
 
   For more information, see [How at.js Manages Flicker](/src/pages/implement/client-side/atjs/how-atjs-works/manage-flicker-with-atjs.md).
@@ -101,12 +107,12 @@ You can override the following settings:
 
 ### decisioningMethod
 
-* **Type**: String 
-* **Default Value**: server-side 
-* **Other Values**: on-device, hybrid 
+* **Type**: String
+* **Default Value**: server-side
+* **Other Values**: on-device, hybrid
 * **Description**: See Decisioning Methods below.
 
-  **Decisioning Methods** 
+  **Decisioning Methods**
 
   With on-device decisioning, Target introduces a new setting called Decisioning Method that dictates how at.js delivers your experiences. The `decisioningMethod` has three values: server-side only, on-device only, and hybrid. When `decisioningMethod` is set in `targetGlobalSettings()`, it acts as the default decisioning method for all Target decisions.
 
@@ -114,33 +120,33 @@ You can override the following settings:
 
   Server-side only is the default decisioning method that is set out of the box when at.js 2.5+ is implemented and deployed on your web properties.
 
-  Using server-side only as the default configuration means that all decisions are made on the Target edge network, which involves a blocking server call. This approach can introduce incremental latency, but it also provides significant benefits, such as giving you the ability to apply Target’s machine-learning capabilities that include [Recommendations](https://experienceleague.adobe.com/docs/target/using/recommendations/recommendations.html), [Automated Personalization](https://experienceleague.adobe.com/docs/target/using/activities/automated-personalization/automated-personalization.html) (AP), and [Auto-Target](https://experienceleague.adobe.com/docs/target/using/activities/auto-target/auto-target-to-optimize.html) activities. 
+  Using server-side only as the default configuration means that all decisions are made on the Target edge network, which involves a blocking server call. This approach can introduce incremental latency, but it also provides significant benefits, such as giving you the ability to apply Target’s machine-learning capabilities that include [Recommendations](https://experienceleague.adobe.com/docs/target/using/recommendations/recommendations.html), [Automated Personalization](https://experienceleague.adobe.com/docs/target/using/activities/automated-personalization/automated-personalization.html) (AP), and [Auto-Target](https://experienceleague.adobe.com/docs/target/using/activities/auto-target/auto-target-to-optimize.html) activities.
 
-  Furthermore, enhancing your personalized experiences by using Target’s user profile, which is persisted across sessions and channels, can provide powerful outcomes for your business. 
+  Furthermore, enhancing your personalized experiences by using Target’s user profile, which is persisted across sessions and channels, can provide powerful outcomes for your business.
 
   Lastly, server-side only lets you use the Adobe Experience Cloud and fine-tune audiences that can be targeted against through Audience Manager and Adobe Analytics segments.
 
   **On-device only**:
 
-  On-device only is the decisioning method that must be set in at.js 2.5+ when on-device decisioning should be used only throughout your web pages. 
+  On-device only is the decisioning method that must be set in at.js 2.5+ when on-device decisioning should be used only throughout your web pages.
 
-  On-device decisioning can deliver your experiences and personalization activities at blazing fast speed because the decisions are made from a cached rules artifact that contains all of your activities that qualify for on-device decisioning. 
+  On-device decisioning can deliver your experiences and personalization activities at blazing fast speed because the decisions are made from a cached rules artifact that contains all of your activities that qualify for on-device decisioning.
 
-  To learn more about which activities qualify for on-device decisioning, see the supported features section. 
+  To learn more about which activities qualify for on-device decisioning, see the supported features section.
 
   This decisioning method should be used only if performance is highly critical across all the pages that require decisions from Target. Furthermore, keep in mind that when this decisioning method is selected, your Target activities that do not qualify for on-device decisioning will not be delivered or executed. The at.js library 2.5+ is configured to only look for the cached rules artifact to make decisions.
 
   **Hybrid**:
 
-  Hybrid is the decisioning method that must be set in at.js 2.5+ when both on-device decisioning and activities that require a network call to the Adobe Target Edge network must be executed. 
+  Hybrid is the decisioning method that must be set in at.js 2.5+ when both on-device decisioning and activities that require a network call to the Adobe Target Edge network must be executed.
 
-  When you are managing both on-device decisioning activities and server-side activities, it can be a bit complicated and tedious when thinking about how to deploy and provision Target on your pages. With hybrid as the decisioning method, Target knows when it must make a server call to the Adobe Target Edge network for activities that require server-side execution, and also when to only execute on-device decisions. 
+  When you are managing both on-device decisioning activities and server-side activities, it can be a bit complicated and tedious when thinking about how to deploy and provision Target on your pages. With hybrid as the decisioning method, Target knows when it must make a server call to the Adobe Target Edge network for activities that require server-side execution, and also when to only execute on-device decisions.
 
   The JSON rules artifact includes metadata to inform at.js whether an mbox has a server-side activity running or an on-device decisioning activity. This decisioning method ensures that activities you intend to be delivered quickly are done through on-device decisioning and for activities that require more powerful ML-driven personalization, those activities are done via the Adobe Target Edge network.
 
 ### defaultContentHiddenStyle
 
-* **Type**: String 
+* **Type**: String
 * **Default Value**: visibility: hidden
 * **Description**: Used only for wrapping mboxes that use DIV with class name "mboxDefault" and are executed via `mboxCreate()`, `mboxUpdate()`, or `mboxDefine()` to hide default content.
 
@@ -164,7 +170,7 @@ The deviceIdLifetime setting is overrideable in at.js version 2.3.1 or later.
 
 * **Type**: Boolean
 * **Default Value**: true
-* **Description**: When enabled, a Target request to retrieve experiences and DOM manipulation to render the experiences is executed automatically. Furthermore, Target calls can be executed manually via `getOffer(s)` / `applyOffer(s)`. 
+* **Description**: When enabled, a Target request to retrieve experiences and DOM manipulation to render the experiences is executed automatically. Furthermore, Target calls can be executed manually via `getOffer(s)` / `applyOffer(s)`.
 
   When disabled, Target requests are not automatically or manually executed.
 
@@ -176,7 +182,7 @@ The deviceIdLifetime setting is overrideable in at.js version 2.3.1 or later.
 
 ### imsOrgId
 
-* **Type**: Sting 
+* **Type**: String
 * **Default Value**: true
 * **Description**: Represents the IMS ORG ID.
 
@@ -184,7 +190,7 @@ The deviceIdLifetime setting is overrideable in at.js version 2.3.1 or later.
 
 * **Type**: Boolean
 * **Default Value**: false
-* **Description**: Target provides opt-in functionality support via Adobe Experience Platform to help support your consent management strategy. Opt-in functionality lets customers control how and when the Target tag is fired. There is also an option via Adobe Experience Platform to pre-approve the Target tag. To enable the ability to use Opt-In in the Target at.js library, add the `optinEnabled=true` setting. In Adobe Experience Platform you must select “enable” from the GDPR Opt-In drop-down list in the extension installation view. See the [Adobe Experience Platform documentation](/src/pages/implement/client-side/atjs/how-to-deployatjs/implement-target-using-adobe-launch.md) for more details. For more information about this setting as it relates to privacy and data protection regulations, including the European Union’s General Data Protection Regulation (GDPR) and the California Consumer Privacy Act (CCPA), see [Privacy and data protection regulations](/src/pages/before-implement/privacy/cmp-privacy-and-general-data-protection-regulation.md).  
+* **Description**: Target provides opt-in functionality support via Adobe Experience Platform to help support your consent management strategy. Opt-in functionality lets customers control how and when the Target tag is fired. There is also an option via Adobe Experience Platform to pre-approve the Target tag. To enable the ability to use Opt-In in the Target at.js library, add the `optinEnabled=true` setting. In Adobe Experience Platform you must select “enable” from the GDPR Opt-In drop-down list in the extension installation view. See the [Adobe Experience Platform documentation](/src/pages/implement/client-side/atjs/how-to-deployatjs/implement-target-using-adobe-launch.md) for more details. For more information about this setting as it relates to privacy and data protection regulations, including the European Union’s General Data Protection Regulation (GDPR) and the California Consumer Privacy Act (CCPA), see [Privacy and data protection regulations](/src/pages/before-implement/privacy/cmp-privacy-and-general-data-protection-regulation.md).
 
 ### optoutEnabled
 
@@ -212,6 +218,18 @@ The deviceIdLifetime setting is overrideable in at.js version 2.3.1 or later.
 * **Default Value**: true
 * **Description**: When enabled, automatically retrieve experiences that must be returned on page load.
 
+### pollingInterval
+
+* **Type**: Number
+* **Default Value**: 300000 (Five minutes in milliseconds)
+* **Description**: Interval that at.js fetches a new version of an artifact and updates the cache
+
+### propertyToken
+
+* **Type**: String
+* **Default Value**: None
+* **Description**: **Target Property Token**. If specified here, all `getOffers` calls will use this value. **For on-device decisioning**, the SDK will only download the artifact that contains the qualified activities for the property token set in `propertyToken`|
+
 ### secureOnly
 
 * **Type**: Boolean
@@ -225,7 +243,7 @@ The deviceIdLifetime setting is overrideable in at.js version 2.3.1 or later.
 * **Description**: In at.js 0.9.6, Target introduced this new setting that can be overridden via `targetGlobalSettings`.
 
   The `selectorsPollingTimeout` setting represents how long the client is willing to wait for all the elements identified by selectors to appear on the page.
-  
+
   Activities created via the Visual Experience Composer (VEC) have offers that contain selectors.
 
 ### serverDomain
@@ -271,14 +289,14 @@ This function can be defined before at.js is loaded or in **Administration** > *
 The Library Header field allows you to enter free-form JavaScript. The customization code should look something similar to the following example:
 
 ```javascript
-window.targetGlobalSettings = {  
-   timeout: 200, // using custom timeout  
-   visitorApiTimeout: 500, // using custom API timeout  
-   enabled: document.location.href.indexOf('https://www.adobe.com') >= 0 // enabled ONLY on adobe.com  
+window.targetGlobalSettings = {
+   timeout: 200, // using custom timeout
+   visitorApiTimeout: 500, // using custom API timeout
+   enabled: document.location.href.indexOf('https://www.adobe.com') >= 0 // enabled ONLY on adobe.com
 };
 ```
 
-## Data Providers 
+## Data Providers
 
 This setting lets customers gather data from third-party data providers, such as Demandbase, BlueKai, and custom services, and pass the data to Target as mbox parameters in the global mbox request. It supports the collection of data from multiple providers via async and sync requests. Using this approach makes it easy to manage flicker of default page content, while including independent timeouts for each provider to limit the impact on page performance
 
@@ -307,18 +325,18 @@ Each data provider has the following structure:
 The following example shows where the data provider is using sync execution:
 
 ```javascript
-var syncDataProvider = { 
-  name: "simpleDataProvider", 
-  version: "1.0.0", 
-  provider: function(callback) { 
-    callback(null, {t1: 1}); 
-  } 
-}; 
-  
-window.targetGlobalSettings = { 
-  dataProviders: [ 
-    syncDataProvider 
-  ] 
+var syncDataProvider = {
+  name: "simpleDataProvider",
+  version: "1.0.0",
+  provider: function(callback) {
+    callback(null, {t1: 1});
+  }
+};
+
+window.targetGlobalSettings = {
+  dataProviders: [
+    syncDataProvider
+  ]
 };
 ```
 
@@ -327,21 +345,21 @@ After at.js processes `window.targetGlobalSettings.dataProviders`, the Target re
 The following is an example if the parameters that you want to add to the Target request are fetched from a third-party service, such as Bluekai, Demandbase, and so forth:
 
 ```javascript
-var blueKaiDataProvider = { 
-   name: "blueKai", 
-   version: "1.0.0", 
-   provider: function(callback) { 
-      // simulating network request 
-     setTimeout(function() { 
-       callback(null, {t1: 1, t2: 2, t3: 3}); 
-     }, 1000); 
-   } 
-} 
-  
-window.targetGlobalSettings = { 
-   dataProviders: [ 
-      blueKaiDataProvider 
-   ] 
+var blueKaiDataProvider = {
+   name: "blueKai",
+   version: "1.0.0",
+   provider: function(callback) {
+      // simulating network request
+     setTimeout(function() {
+       callback(null, {t1: 1, t2: 2, t3: 3});
+     }, 1000);
+   }
+}
+
+window.targetGlobalSettings = {
+   dataProviders: [
+      blueKaiDataProvider
+   ]
 };
 ```
 
@@ -350,49 +368,49 @@ After at.js processes `window.targetGlobalSettings.dataProviders`, the Target re
 The following example uses data providers to collect weather API data and send it as parameters in a Target request. The Target request will have additional params, such as `country` and `weatherCondition`.
 
 ```javascript
-var weatherProvider = { 
-      name: "weather-api", 
-      version: "1.0.0", 
-      timeout: 2000, 
-      provider: function(callback) { 
-        var API_KEY = "caa84fc6f5dc77b6372d2570458b8699"; 
-        var lat = 44.426767399999996; 
-        var lon = 26.1025384; 
-        var url = "//api.openweathermap.org/data/2.5/weather?"; 
-        var data = { 
-          lat: lat, 
-          lon: lon, 
-          appId: API_KEY 
-        } 
- 
-        $.ajax({ 
-          type: "GET", 
-                url: url, 
-          dataType: "json", 
-          data: data, 
-          success: function(data) { 
-            console.log("Weather data", data); 
-            callback(null, { 
-              country: data.sys.country, 
-              weatherCondition: data.weather[0].main 
-            }); 
-          }, 
-          error: function(err) { 
-            console.log("Error", err); 
-            callback(err); 
-          } 
-        });         
-      } 
-    }; 
- 
-    window.targetGlobalSettings = { 
-      dataProviders: [weatherProvider] 
+var weatherProvider = {
+      name: "weather-api",
+      version: "1.0.0",
+      timeout: 2000,
+      provider: function(callback) {
+        var API_KEY = "caa84fc6f5dc77b6372d2570458b8699";
+        var lat = 44.426767399999996;
+        var lon = 26.1025384;
+        var url = "//api.openweathermap.org/data/2.5/weather?";
+        var data = {
+          lat: lat,
+          lon: lon,
+          appId: API_KEY
+        }
+
+        $.ajax({
+          type: "GET",
+                url: url,
+          dataType: "json",
+          data: data,
+          success: function(data) {
+            console.log("Weather data", data);
+            callback(null, {
+              country: data.sys.country,
+              weatherCondition: data.weather[0].main
+            });
+          },
+          error: function(err) {
+            console.log("Error", err);
+            callback(err);
+          }
+        });
+      }
+    };
+
+    window.targetGlobalSettings = {
+      dataProviders: [weatherProvider]
     };
 ```
 
 Consider the following when working with the `dataProviders` setting:
 
-* If the data providers added to `window.targetGlobalSettings.dataProviders` are async, they will be executed in parallel. The Visitor API request will be executed in parallel with functions added to `window.targetGlobalSettings.dataProviders` to allow a minimum wait time. 
+* If the data providers added to `window.targetGlobalSettings.dataProviders` are async, they will be executed in parallel. The Visitor API request will be executed in parallel with functions added to `window.targetGlobalSettings.dataProviders` to allow a minimum wait time.
 * at.js won't try to cache the data. If the data provider fetches data only once, the data provider should make sure that data is cached and, when the provider function is invoked, serve the cache data for the second invocation.
 
 ## Content Security Policy
@@ -425,7 +443,7 @@ After `cspScriptNonce` and `cspStyleNonce` settings are specified, at.js 2.3.0+ 
 ### Pre-requisites
 
 You must have a hybrid integration of Target.
-  
+
 * **Server-side**:  You must use the [Delivery API](/src/pages/implement/delivery-api/index.md) or [Target SDKs](../../implement/server-side/sdk-guides/).
 * **Client-side**: You must use [at.js version 2.2 or later](/src/pages/implement/client-side/atjs/target-atjs-versions.md).
 

--- a/src/pages/implement/client-side/atjs/atjs-functions/targetglobalsettings.md
+++ b/src/pages/implement/client-side/atjs/atjs-functions/targetglobalsettings.md
@@ -55,7 +55,6 @@ You can override the following settings:
 * **Default Value**: None
 * **Description**: A fully qualified url to the [on-device decisioning rule artifact](../../../server-side/sdk-guides/on-device-decisioning/rule-artifact-overview.md)
 
-
 ### bodyHiddenStyle
 
 * **Type**: String
@@ -229,7 +228,7 @@ The deviceIdLifetime setting is overrideable in at.js version 2.3.1 or later.
 
 * **Type**: String
 * **Default Value**: None
-* **Description**: If specified here, all `getOffers` calls will use this value. **For on-device decisioning**, the at.js will only download the artifact that contains the qualified activities for the property token set in `propertyToken`
+* **Description**: If specified here, all `getOffers` calls will use this value. **For on-device decisioning**, at.js will only download the artifact that contains the qualified activities for the property token set in `propertyToken`
 
 ### secureOnly
 
@@ -482,7 +481,7 @@ const PAGE_TEMPLATE = `
 
 A sample `serverState` object JSON for view prefetch looks as follows:
 
-```
+```javascript
 {
  "request": {
   "requestId": "076ace1cd3624048bae1ced1f9e0c536",
@@ -566,7 +565,7 @@ Consider the following when using `serverState`:
 
   * **Note**:  Currently, mboxes retrieved on the server-side is not supported in `serverState`.
 
-* When applying `serverState `offers, at.js takes into consideration `pageLoadEnabled` and `viewsEnabled` settings, e.g. Page Load offers will not be applied if the `pageLoadEnabled` setting is false.
+* When applying `serverState` offers, at.js takes into consideration `pageLoadEnabled` and `viewsEnabled` settings, e.g. Page Load offers will not be applied if the `pageLoadEnabled` setting is false.
 
   To turn these settings on, enable the toggle in **Administration > Implementation > Edit > Page Load Enabled**.
 

--- a/src/pages/implement/client-side/atjs/atjs-functions/targetglobalsettings.md
+++ b/src/pages/implement/client-side/atjs/atjs-functions/targetglobalsettings.md
@@ -53,7 +53,8 @@ You can override the following settings:
 
 * **Type**: String
 * **Default Value**: None
-* **Description**: A fully qualified url to the [on-device decisioning rule artifact](../../sdk-guides/on-device-decisioning/rule-artifact/index.md). Overrides internally determined location.
+* **Description**: A fully qualified url to the [on-device decisioning rule artifact](../../../server-side/sdk-guides/on-device-decisioning/rule-artifact-overview.md)
+
 
 ### bodyHiddenStyle
 
@@ -228,7 +229,7 @@ The deviceIdLifetime setting is overrideable in at.js version 2.3.1 or later.
 
 * **Type**: String
 * **Default Value**: None
-* **Description**: **Target Property Token**. If specified here, all `getOffers` calls will use this value. **For on-device decisioning**, the SDK will only download the artifact that contains the qualified activities for the property token set in `propertyToken`|
+* **Description**: If specified here, all `getOffers` calls will use this value. **For on-device decisioning**, the at.js will only download the artifact that contains the qualified activities for the property token set in `propertyToken`
 
 ### secureOnly
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The solution to the customer issue logged in the ticket below is to configure the `pollingInterval` setting in `targetGlobalSettings()`, however that was missing from the documentation. This PR adds that setting, along with `propertyToken` and `artifactLocation` to the documentation. 

## Related Issue

https://jira.corp.adobe.com/browse/TNT-46359

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
